### PR TITLE
Changed the RegEx to match the separator of the rules and parameters

### DIFF
--- a/src/Pecee/Http/Input/InputValidatorItem.php
+++ b/src/Pecee/Http/Input/InputValidatorItem.php
@@ -46,14 +46,11 @@ class InputValidatorItem{
         $matches = array();
         //Add "\\\\" to allow one Backslash
         //https://stackoverflow.com/questions/11044136/right-way-to-escape-backslash-in-php-regex/15369828#answer-15369828
-        preg_match_all('/([a-zA-Z\\\\=\/<>]+)(?::([a-z-A-Z0-9=<>]+))*/', $settings, $matches);
+        preg_match_all('/([a-zA-Z\\\\=\/<>]+)(?::([^:\|]+)*)?\|?/', $settings, $matches);
         for($i = 0; $i < sizeof($matches[0]); $i++){
             $tag = $matches[1][$i];
-            $attributes = array();
-            for($j = 2; $j < sizeof($matches); $j++){
-                if($matches[$j][$i] !== '')
-                    $attributes[] = $matches[$j][$i];
-            }
+            $attributes = array_filter(explode(',', $matches[2][$i]));
+
             $this->addRuleByTag($tag, $attributes);
         }
     }


### PR DESCRIPTION
Hi @DeveloperMarius,

Sorry for the delay on making this PR, it was a busy weekend.

> could you integrate that the characters in the block list are allowed when they have a preceding \? I think we could do this using a look behind.

I could not accomplish this using a lookbehind, I made some tests whit the [RegEx](https://regex101.com/r/wnbG1X/3) but without luck, if you have time to take a look, maybe you can find a way to do this.