### PR TITLE
Fix json_encode deprecation in PHP8.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -2061,6 +2061,7 @@ class ArticleController{
 
 }
 ```
+- Dangerous route match behavior with trim. See `RouterUrlTest@testDangerousTrimBehavior`
 
 ## Feedback and development
 

--- a/src/Pecee/Http/Input/Exceptions/InputValidationException.php
+++ b/src/Pecee/Http/Input/Exceptions/InputValidationException.php
@@ -10,9 +10,9 @@ class InputValidationException extends Exception
 {
 
     /**
-     * @var Validation $validation
+     * @var Validation|null $validation
      */
-    private Validation $validation;
+    private ?Validation $validation;
 
     public function __construct(string $message, ?Validation $validation = null, int $code = 0, Throwable $previous = null)
     {

--- a/src/Pecee/Http/Request.php
+++ b/src/Pecee/Http/Request.php
@@ -3,6 +3,7 @@
 namespace Pecee\Http;
 
 use Closure;
+use Pecee\Http\Exceptions\MalformedUrlException;
 use Pecee\Http\Input\Exceptions\InputValidationException;
 use Pecee\Http\Input\InputHandler;
 use Pecee\Http\Input\InputValidator;
@@ -138,11 +139,11 @@ class Request
         // Check if special IIS header exist, otherwise use default.
         $url = $this->getHeader('unencoded-url');
         if($url !== null){
-            $this->setUrl(new Url($url));
+            $this->setUrl(new Url($url, false));
         }else{
             $request_uri = $this->getHeader('request-uri');
             if($request_uri !== null)
-                $this->setUrl(new Url(urldecode($request_uri)));
+                $this->setUrl(new Url(urldecode($request_uri), false));
         }
         $this->setContentType((string)$this->getHeader('content-type'));
         $this->setMethod((string)($_POST[static::FORCE_METHOD_KEY] ?? $this->getHeader('request-method')));

--- a/src/Pecee/Http/Response.php
+++ b/src/Pecee/Http/Response.php
@@ -107,7 +107,7 @@ class Response
      * @throws InvalidArgumentException
      */
     #[NoReturn]
-    public function json(mixed $value, ?int $options = null, int $dept = 512): void
+    public function json(mixed $value, int $options = 0, int $dept = 512): void
     {
         if (($value instanceof JsonSerializable) === false && is_array($value) === false) {
             throw new InvalidArgumentException('Invalid type for parameter "value". Must be of type array or object implementing the \JsonSerializable interface.');

--- a/src/Pecee/Http/Response.php
+++ b/src/Pecee/Http/Response.php
@@ -102,9 +102,8 @@ class Response
     /**
      * Json encode
      * @param array|JsonSerializable $value
-     * @param int|null $options JSON options Bitmask consisting of JSON_HEX_QUOT, JSON_HEX_TAG, JSON_HEX_AMP, JSON_HEX_APOS, JSON_NUMERIC_CHECK, JSON_PRETTY_PRINT, JSON_UNESCAPED_SLASHES, JSON_FORCE_OBJECT, JSON_PRESERVE_ZERO_FRACTION, JSON_UNESCAPED_UNICODE, JSON_PARTIAL_OUTPUT_ON_ERROR.
+     * @param int $options JSON options Bitmask consisting of JSON_HEX_QUOT, JSON_HEX_TAG, JSON_HEX_AMP, JSON_HEX_APOS, JSON_NUMERIC_CHECK, JSON_PRETTY_PRINT, JSON_UNESCAPED_SLASHES, JSON_FORCE_OBJECT, JSON_PRESERVE_ZERO_FRACTION, JSON_UNESCAPED_UNICODE, JSON_PARTIAL_OUTPUT_ON_ERROR.
      * @param int $dept JSON debt.
-     * @throws InvalidArgumentException
      */
     #[NoReturn]
     public function json(mixed $value, int $options = 0, int $dept = 512): void

--- a/src/Pecee/Http/Url.php
+++ b/src/Pecee/Http/Url.php
@@ -56,20 +56,21 @@ class Url implements JsonSerializable
      * Url constructor.
      *
      * @param string|null $url
+     * @param bool $includesHost
      * @throws MalformedUrlException
      */
-    public function __construct(?string $url)
+    public function __construct(?string $url, bool $includesHost = true)
     {
         $this->originalUrl = $url;
 
         if ($url !== null && $url !== '/') {
-            $data = $this->parseUrl($url);
+            $data = $this->parseUrl($includesHost ? $url : 'https://host.com' . $url);
 
-            $this->scheme = $data['scheme'] ?? null;
-            $this->host = $data['host'] ?? null;
-            $this->port = $data['port'] ?? null;
-            $this->username = $data['user'] ?? null;
-            $this->password = $data['pass'] ?? null;
+            $this->scheme = $includesHost ? ($data['scheme'] ?? null) : null;
+            $this->host = $includesHost ? ($data['host'] ?? null) : null;
+            $this->port = $includesHost ? ($data['port'] ?? null) : null;
+            $this->username = $includesHost ? ($data['user'] ?? null) : null;
+            $this->password = $includesHost ? ($data['pass'] ?? null) : null;
 
             if (isset($data['path']) === true) {
                 $this->setPath($data['path']);

--- a/src/Pecee/SimpleRouter/Router.php
+++ b/src/Pecee/SimpleRouter/Router.php
@@ -31,7 +31,7 @@ class Router
      * Current request
      * @var Request|null
      */
-    protected ?Request $request;
+    protected ?Request $request = null;
 
     /**
      * Defines if a route is currently being processed.
@@ -695,7 +695,7 @@ class Router
         ]);
 
         if ($name === '' && $parameters === '') {
-            return new Url('/');
+            return new Url('/', false);
         }
 
         /* Only merge $_GET when all parameters are null */

--- a/src/Pecee/SimpleRouter/SimpleRouter.php
+++ b/src/Pecee/SimpleRouter/SimpleRouter.php
@@ -468,7 +468,7 @@ class SimpleRouter
         try {
             return static::router()->getUrl($name, $parameters, $getParams);
         } catch (Exception $e) {
-            return new Url('/');
+            return new Url('/', false);
         }
     }
 

--- a/tests/Pecee/SimpleRouter/CsrfVerifierTest.php
+++ b/tests/Pecee/SimpleRouter/CsrfVerifierTest.php
@@ -21,7 +21,7 @@ class CsrfVerifierTest extends \PHPUnit\Framework\TestCase
 
         $request = new Request(false);
         $request->setMethod(\Pecee\Http\Request::REQUEST_TYPE_POST);
-        $request->setUrl(new \Pecee\Http\Url('/page'));
+        $request->setUrl(new \Pecee\Http\Url('/page', false));
         $request->fetch();
 
         $csrf->handle($request);
@@ -42,7 +42,7 @@ class CsrfVerifierTest extends \PHPUnit\Framework\TestCase
 
         $request = new Request(false);
         $request->setMethod(\Pecee\Http\Request::REQUEST_TYPE_POST);
-        $request->setUrl(new \Pecee\Http\Url('/page'));
+        $request->setUrl(new \Pecee\Http\Url('/page', false));
         $request->fetch();
 
         $csrf->handle($request);
@@ -54,16 +54,16 @@ class CsrfVerifierTest extends \PHPUnit\Framework\TestCase
         $csrf = new DummyCsrfVerifier();
         $request = $router->getRequest();
 
-        $request->setUrl(new \Pecee\Http\Url('/exclude-page'));
+        $request->setUrl(new \Pecee\Http\Url('/exclude-page', false));
         $this->assertTrue($csrf->testSkip($router->getRequest()));
 
-        $request->setUrl(new \Pecee\Http\Url('/exclude-all/page'));
+        $request->setUrl(new \Pecee\Http\Url('/exclude-all/page', false));
         $this->assertTrue($csrf->testSkip($router->getRequest()));
 
-        $request->setUrl(new \Pecee\Http\Url('/exclude-all/include-page'));
+        $request->setUrl(new \Pecee\Http\Url('/exclude-all/include-page', false));
         $this->assertFalse($csrf->testSkip($router->getRequest()));
 
-        $request->setUrl(new \Pecee\Http\Url('/include-page'));
+        $request->setUrl(new \Pecee\Http\Url('/include-page', false));
         $this->assertFalse($csrf->testSkip($router->getRequest()));
     }
 

--- a/tests/Pecee/SimpleRouter/Dummy/Handler/ExceptionHandlerFirst.php
+++ b/tests/Pecee/SimpleRouter/Dummy/Handler/ExceptionHandlerFirst.php
@@ -7,7 +7,7 @@ class ExceptionHandlerFirst implements \Pecee\SimpleRouter\Handlers\IExceptionHa
 	    global $stack;
 	    $stack[] = static::class;
 
-		$request->setUrl(new \Pecee\Http\Url('/'));
+		$request->setUrl(new \Pecee\Http\Url('/', false));
 	}
 
 }

--- a/tests/Pecee/SimpleRouter/Dummy/Handler/ExceptionHandlerSecond.php
+++ b/tests/Pecee/SimpleRouter/Dummy/Handler/ExceptionHandlerSecond.php
@@ -7,7 +7,7 @@ class ExceptionHandlerSecond implements \Pecee\SimpleRouter\Handlers\IExceptionH
         global $stack;
         $stack[] = static::class;
 
-        $request->setUrl(new \Pecee\Http\Url('/'));
+        $request->setUrl(new \Pecee\Http\Url('/', false));
 	}
 
 }

--- a/tests/Pecee/SimpleRouter/RouterUrlTest.php
+++ b/tests/Pecee/SimpleRouter/RouterUrlTest.php
@@ -7,6 +7,13 @@ require_once 'Dummy/Handler/ExceptionHandler.php';
 class RouterUrlTest extends \PHPUnit\Framework\TestCase
 {
 
+    public function testMultipleSlashes(){
+        TestRouter::get('///test/test2', 'DummyController@method1');
+
+        TestRouter::debugNoReset('///test/test2/', 'get');
+        $this->assertEquals('/test/test2/', TestRouter::router()->getRequest()->getLoadedRoute()->getUrl());
+    }
+
     public function testIssue253()
     {
         TestRouter::get('/', 'DummyController@method1');

--- a/tests/Pecee/SimpleRouter/RouterUrlTest.php
+++ b/tests/Pecee/SimpleRouter/RouterUrlTest.php
@@ -7,11 +7,23 @@ require_once 'Dummy/Handler/ExceptionHandler.php';
 class RouterUrlTest extends \PHPUnit\Framework\TestCase
 {
 
-    public function testMultipleSlashes(){
-        TestRouter::get('///test/test2', 'DummyController@method1');
+    public function testDangerousTrimBehavior(){
+        //Test / show that this is possible
 
-        TestRouter::debugNoReset('///test/test2/', 'get');
+        //trim request url: Route@parseParameters
+        //trim route urls: LoadableRoute@setUrl
+        TestRouter::get('/test/test2', 'DummyController@method1');
+        TestRouter::debugNoReset('/test/test2', 'get');
         $this->assertEquals('/test/test2/', TestRouter::router()->getRequest()->getLoadedRoute()->getUrl());
+        TestRouter::debugNoReset('//test/test2', 'get');
+        $this->assertEquals('/test/test2/', TestRouter::router()->getRequest()->getLoadedRoute()->getUrl());
+        TestRouter::debugNoReset('///test/test2', 'get');
+        $this->assertEquals('/test/test2/', TestRouter::router()->getRequest()->getLoadedRoute()->getUrl());
+    }
+
+    public function testMultipleSlashes(){
+        $this->expectException(\Pecee\SimpleRouter\Exceptions\NotFoundHttpException::class);
+        TestRouter::debugNoReset('///test/test2', 'get');
     }
 
     public function testIssue253()

--- a/tests/Pecee/SimpleRouter/RouterUrlTest.php
+++ b/tests/Pecee/SimpleRouter/RouterUrlTest.php
@@ -19,11 +19,15 @@ class RouterUrlTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('/test/test2/', TestRouter::router()->getRequest()->getLoadedRoute()->getUrl());
         TestRouter::debugNoReset('///test/test2', 'get');
         $this->assertEquals('/test/test2/', TestRouter::router()->getRequest()->getLoadedRoute()->getUrl());
+
+        TestRouter::resetRouter();
     }
 
     public function testMultipleSlashes(){
         $this->expectException(\Pecee\SimpleRouter\Exceptions\NotFoundHttpException::class);
         TestRouter::debugNoReset('///test/test2', 'get');
+
+        TestRouter::resetRouter();
     }
 
     public function testIssue253()

--- a/tests/TestRouter.php
+++ b/tests/TestRouter.php
@@ -12,7 +12,7 @@ class TestRouter extends \Pecee\SimpleRouter\SimpleRouter
     {
         $request = static::request();
 
-        $request->setUrl((new \Pecee\Http\Url($testUrl))->setHost('local.unitTest'));
+        $request->setUrl((new \Pecee\Http\Url($testUrl, false))->setHost('local.unitTest'));
         $request->setMethod($testMethod);
 
         static::start();


### PR DESCRIPTION
Hi,

I'm using the latest version (5.1.0.6) and php8.2.

When I use `response()->json($value)` I get the following warning :
```
Deprecated:  json_encode(): Passing null to parameter #2 ($flags) of type int is deprecated in vendor/developermarius/simple-router/src/Pecee/Http/Response.php on line 117
```

Since PHP8.1, we cannot pass null to non-nullable internal function parameters.