### PR TITLE
Fix loadable route #18

### DIFF
--- a/src/Pecee/SimpleRouter/Route/ILoadableRoute.php
+++ b/src/Pecee/SimpleRouter/Route/ILoadableRoute.php
@@ -47,16 +47,6 @@ interface ILoadableRoute extends IRoute
     public function prependUrl(string $url): self;
 
     /**
-     * Sets the router name, which makes it easier to obtain the url or router at a later point.
-     * Alias for LoadableRoute::setName().
-     *
-     * @param string|array $name
-     * @return static
-     * @see LoadableRoute::setName()
-     */
-    public function name(array|string $name): self;
-
-    /**
      * Returns the provided name for the router.
      *
      * @return string|null

--- a/src/Pecee/SimpleRouter/Route/IRoute.php
+++ b/src/Pecee/SimpleRouter/Route/IRoute.php
@@ -165,6 +165,16 @@ interface IRoute
     public function where(array $options): self;
 
     /**
+     * Sets the router name, which makes it easier to obtain the url or router at a later point.
+     * Alias for LoadableRoute::setName().
+     *
+     * @param string|array $name
+     * @return static
+     * @see LoadableRoute::setName()
+     */
+    public function name(array|string $name): self;
+
+    /**
      * Get parameters
      *
      * @return array

--- a/src/Pecee/SimpleRouter/Route/RouteGroup.php
+++ b/src/Pecee/SimpleRouter/Route/RouteGroup.php
@@ -177,6 +177,20 @@ class RouteGroup extends Route implements IGroupRoute
     {
         return $this->prefix;
     }
+    
+    /**
+     * Sets the router name, which makes it easier to obtain the url or router at a later point.
+     * Alias for RouteGroup::setName().
+     *
+     * @param string $name
+     * @return static
+     * @see RouteGroup::setName()
+     */
+    public function name(array|string $name): IGroupRoute
+    {
+        return $this->setName($name);
+    }
+    
     /**
      * @param string $name
      * @return static


### PR DESCRIPTION
I got an mistake. The `name()` alias must be placed in `IRoute` instead of `ILoadableRoute` - otherwise PHPStan throws an error. This PR fixes this error.

Regarding to https://github.com/DeveloperMarius/simple-php-router/issues/18

Fixed PHPStan error:
`Call to an undefined method Pecee\SimpleRouter\Route\IRoute::name().`